### PR TITLE
Can now change public status of settings and droplet_data

### DIFF
--- a/apps/pages/data_overview.py
+++ b/apps/pages/data_overview.py
@@ -1,8 +1,8 @@
 import streamlit as st
 from apps.services.droplet_data_service import get_all_owned_droplet_data, delete_owned_droplet_dataset, \
-    rename_droplet_data
+    rename_droplet_data, change_data_p_status
 from apps.services.analysis_settings_service import get_all_available_settings, rename_settings, change_description, \
-    delete_settings
+    delete_settings, change_sett_p_status
 from apps.services.sharing_service import get_all_possible_receivers, get_data_receivers, add_remove_data_receiver, \
     get_setting_receivers, add_remove_sett_receiver
 
@@ -22,6 +22,7 @@ def display_owned_data():
         filepath = owned_droplet_datasets[data_id]['filepath']
         upload_time = owned_droplet_datasets[data_id]['upload time']
         data_type = owned_droplet_datasets[data_id]['data_type']
+        public_status = owned_droplet_datasets[data_id]['public']
         label = f"{filename}, upload time: {upload_time}"
         with st.expander(label=label):
             desc, renaming, deletion = st.columns(3)
@@ -50,7 +51,7 @@ def display_owned_data():
                         st.experimental_rerun()
                     else:
                         st.warning("You must confirm if you want this droplet data to be deleted!")
-            sharing, other = st.columns(2)
+            sharing, public = st.columns(2)
             with sharing:
                 options = st.multiselect(label="Share your data with others!",
                                          options=get_all_possible_receivers(), default=get_data_receivers(data_id),
@@ -60,6 +61,11 @@ def display_owned_data():
                         st.warning("No changes made!")
                     else:
                         add_remove_data_receiver(data_id, options)
+            with public:
+                st.checkbox(label="Make this droplet data be public?", value=public_status,
+                            key=f"data_public_{data_id}", on_change=change_data_p_status,
+                            args=[data_id])
+
 
 
 def display_settings():
@@ -116,4 +122,6 @@ def display_settings():
                         else:
                             add_remove_sett_receiver(setting['id'], options)
                 with public:
-                    print()
+                    st.checkbox(label="Make this setting be public?", value=setting['public'],
+                                key=f"setting_public_{setting['id']}", on_change=change_sett_p_status,
+                                args=[setting['id']])

--- a/apps/pages/droplet_datafile_details_page.py
+++ b/apps/pages/droplet_datafile_details_page.py
@@ -1,7 +1,0 @@
-import streamlit as st
-
-
-def droplet_datafile_details_page():
-    filename = st.session_state['cur_datafile']
-    st.header(f"{filename}")
-

--- a/apps/services/analysis_settings_service.py
+++ b/apps/services/analysis_settings_service.py
@@ -8,9 +8,9 @@ def set_default_settings(data_frame):
         'name': "Default",
         'uploader': 'EasyFlow',
         'description': "Default settings for any plot",
+        'public': True,
         'body': {
             'threshold': data_frame['Intensity'].min() + 0.0001,
-
             'droplet_sizes_distribution': {
                 'bin_nr': 5,
                 'bins': "0.0,0.66173,1.32346,1.98519,2.64692,3.30865",
@@ -119,11 +119,11 @@ def change_settings():
 def get_all_available_settings(options: list, settings_dict: dict, owned: bool):
     user_id = get_user_id(st.session_state['username'])
     if owned:
-        query = "SELECT analysis_settings_id, name, body, description, username " \
+        query = "SELECT analysis_settings_id, name, body, description, username, public " \
                 "FROM Analysis_settings, User WHERE uploader=User.user_id AND uploader=%s;"
         val = [user_id]
     else:
-        query = "SELECT A.analysis_settings_id, name, body, description, username " \
+        query = "SELECT A.analysis_settings_id, name, body, description, username, public " \
                 "FROM Analysis_settings as A " \
                 "JOIN User as U ON A.uploader=U.user_id " \
                 "WHERE uploader=%s OR public=TRUE OR A.analysis_settings_id IN " \
@@ -139,6 +139,7 @@ def get_all_available_settings(options: list, settings_dict: dict, owned: bool):
                                'name': row[1],
                                'username': row[4],
                                'description': description,
+                               'public': row[5],
                                'body': body
                                }
     st.session_state['all_settings'] = settings_dict
@@ -172,3 +173,13 @@ def delete_settings(name):
     query = "DELETE FROM Analysis_settings WHERE name=%s AND uploader=%s;"
     vals = (name, user_id)
     execute_query(query, vals)
+
+def change_sett_p_status(sett_id: int):
+    q_for_public_status = f"SELECT public FROM Analysis_settings WHERE analysis_settings_id={sett_id}"
+    old_p = execute_query_to_get_data(q_for_public_status)[0][0]
+    q_to_change_p = f"UPDATE Analysis_settings SET public=%s WHERE analysis_settings_id={sett_id}"
+    if old_p == 1:
+        val = [0]
+    else:
+        val = [1]
+    execute_query(q_to_change_p, val)


### PR DESCRIPTION
Deleted unused droplet_datafile_details_page.py.
When uploading droplet data is_public checkbox is False by default. Added two callback functions for changing public status of settings and data, callback function is called from their respective checkboxes in data_overview.py